### PR TITLE
feat: Add module support to project generation

### DIFF
--- a/src/Myrtus.Clarity.Generator.Business/GeneratorService.cs
+++ b/src/Myrtus.Clarity.Generator.Business/GeneratorService.cs
@@ -6,7 +6,7 @@ namespace Myrtus.Clarity.Generator.Business;
 
 public class GeneratorService
 {
-    public async Task RunGeneratorAsync(string projectName, string outputDir)
+    public async Task RunGeneratorAsync(string projectName, string outputDir, List<string> modulesToAdd)
     {
         await AnsiConsole.Status()
             .StartAsync("Initializing...", async ctx =>
@@ -16,7 +16,7 @@ public class GeneratorService
                 if (config is null) return;
 
                 var generator = new ProjectGenerator(config, ctx);
-                await generator.GenerateProjectAsync(projectName, outputDir);
+                await generator.GenerateProjectAsync(projectName, outputDir, modulesToAdd);
             });
     }
 }

--- a/src/Myrtus.Clarity.Generator.Common/Models/AppSettings.cs
+++ b/src/Myrtus.Clarity.Generator.Common/Models/AppSettings.cs
@@ -3,5 +3,12 @@
     public class AppSettings
     {
         public TemplateSettings Template { get; set; }
+        public List<ModuleSettings> Modules { get; set; } = new List<ModuleSettings>();
+    }
+
+    public class ModuleSettings
+    {
+        public string Name { get; set; }
+        public string GitRepoUrl { get; set; }
     }
 }

--- a/src/Myrtus.Clarity.Generator.Presentation/Program.cs
+++ b/src/Myrtus.Clarity.Generator.Presentation/Program.cs
@@ -9,21 +9,44 @@ public class Program
     {
         AnsiConsole.Write(new FigletText("ClarityGen").Color(Color.Cyan1));
 
-        if (args.Length == 0)
+        string projectName = string.Empty;
+        string outputDirectory = string.Empty;
+        List<string> modulesToAdd = new List<string>();
+
+        for (int i = 0; i < args.Length; i++)
         {
-            var projectName = AnsiConsole.Ask<string>("[yellow]Enter project name:[/]");
-            var outputDirectory = AnsiConsole.Ask<string>("[yellow]Enter output directory (or press Enter for current):[/]");
+            if (args[i].Equals("--add-module", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+            {
+                modulesToAdd.Add(args[i + 1].ToLower());
+                i++; 
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(projectName))
+                {
+                    projectName = args[i];
+                }
+                else if (string.IsNullOrEmpty(outputDirectory))
+                {
+                    outputDirectory = args[i];
+                }
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(projectName))
+        {
+            projectName = AnsiConsole.Ask<string>("[yellow]Enter project name:[/]");
+        }
+
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+        {
+            outputDirectory = AnsiConsole.Ask<string>("[yellow]Enter output directory (or press Enter for current):[/]");
 
             if (string.IsNullOrWhiteSpace(outputDirectory))
                 outputDirectory = AppDomain.CurrentDomain.BaseDirectory;
-
-            args = new[] { projectName, outputDirectory };
         }
 
-        string newProjectName = args[0];
-        string outputDir = args.Length > 1 ? args[1] : AppDomain.CurrentDomain.BaseDirectory;
-
         var generatorService = new GeneratorService();
-        await generatorService.RunGeneratorAsync(newProjectName, outputDir);
+        await generatorService.RunGeneratorAsync(projectName, outputDirectory, modulesToAdd);
     }
 }

--- a/src/Myrtus.Clarity.Generator.Presentation/appsettings.json
+++ b/src/Myrtus.Clarity.Generator.Presentation/appsettings.json
@@ -3,6 +3,13 @@
     "GitRepoUrl": "https://github.com/sercanio/Myrtus.Clarity.git",
     "TemplateName": "Myrtus.Clarity"
   },
+  "Modules": [
+    {
+      "Name": "cms",
+      "GitRepoUrl": "https://github.com/sercanio/Myrtus.Clarity.Module.CMS.git"
+    }
+    // Add more modules here as needed
+  ],
   "Output": {
     "DefaultPath": "."
   },


### PR DESCRIPTION
Updated `RunGeneratorAsync` in `GeneratorService.cs` to accept `modulesToAdd` parameter. Added `Modules` property and `ModuleSettings` class in `AppSettings.cs`. Introduced `_availableModules` dictionary and `AddModuleAsync` method in `ProjectGenerator.cs`. Enhanced `RunProcessAsync` to accept `workingDirectory` parameter. Improved command-line parsing in `Program.cs` to support `--add-module` option. Updated `appsettings.json` to include `Modules` section with module names and Git URLs.