### PR TITLE
Refactor ProjectGenerator and add SkipPaths property

### DIFF
--- a/src/Myrtus.Clarity.Generator.Common/Models/AppSettings.cs
+++ b/src/Myrtus.Clarity.Generator.Common/Models/AppSettings.cs
@@ -4,6 +4,7 @@
     {
         public TemplateSettings Template { get; set; }
         public List<ModuleSettings> Modules { get; set; } = new List<ModuleSettings>();
+        public List<string> SkipPaths { get; set; } = new List<string>();
     }
 
     public class ModuleSettings

--- a/src/Myrtus.Clarity.Generator.Common/ProjectGenerator.cs
+++ b/src/Myrtus.Clarity.Generator.Common/ProjectGenerator.cs
@@ -12,7 +12,7 @@ namespace Myrtus.Clarity.Generator.Common
         private readonly string _tempDir;
 
         // Mapping of module names to their Git repository URLs
-        private readonly Dictionary<string, string> _availableModules = new Dictionary<string, string>
+        private readonly Dictionary<string, string> _availableModules = new()
         {
             { "cms", "https://github.com/sercanio/Myrtus.Clarity.Module.CMS.git" }
             // Add more modules here as needed
@@ -30,10 +30,10 @@ namespace Myrtus.Clarity.Generator.Common
             try
             {
                 await CloneTemplateRepositoryAsync();
-                await RenameProjectAsync(projectName);
                 await UpdateSubmodulesAsync();
+                await RenameProjectAsync(projectName);
 
-                if (modulesToAdd != null && modulesToAdd.Count > 0)
+                if (modulesToAdd is { Count: > 0 })
                 {
                     foreach (var module in modulesToAdd)
                     {
@@ -52,58 +52,11 @@ namespace Myrtus.Clarity.Generator.Common
             }
             finally
             {
+                // Safely delete the temporary directory by removing read-only attributes first
                 if (Directory.Exists(_tempDir))
                 {
-                    Directory.Delete(_tempDir, true);
+                    ForceDeleteDirectory(_tempDir);
                 }
-            }
-        }
-
-        private async Task AddModuleAsync(string moduleName, string repoUrl)
-        {
-            _status.Status = $"[bold yellow]Adding module '{moduleName}' as a submodule...[/]";
-
-            // Define the relative path where the module will be added
-            string modulePath = Path.Combine("modules", moduleName); // Relative path
-
-            // Ensure the 'modules' directory exists
-            string modulesDirectory = Path.Combine(_tempDir, "modules");
-            if (!Directory.Exists(modulesDirectory))
-            {
-                Directory.CreateDirectory(modulesDirectory);
-            }
-
-            // Run 'git submodule add <repoUrl> <modulePath>' within the cloned template repository
-            var gitCommand = $"submodule add {repoUrl} \"{modulePath}\"";
-            var result = await RunProcessAsync("git", gitCommand, _tempDir);
-
-            if (!result.Success)
-            {
-                AnsiConsole.MarkupLine($"[red]Error:[/] Failed to add module '{moduleName}': {result.Error}");
-                return;
-            }
-            else
-            {
-                AnsiConsole.MarkupLine($"[green]Success:[/] Module '{moduleName}' added successfully.");
-            }
-
-            // Prevent initialization of nested submodules (like 'core/') within the CMS module
-            // by removing the .gitmodules entry for the nested submodule
-            string cmsGitModulesPath = Path.Combine(_tempDir, ".gitmodules");
-            if (File.Exists(cmsGitModulesPath))
-            {
-                var lines = File.ReadAllLines(cmsGitModulesPath).ToList();
-                // Assuming that the nested submodule is named 'core'
-                lines.RemoveAll(line => line.Contains($"path = {modulePath}/core", StringComparison.OrdinalIgnoreCase));
-
-                await File.WriteAllLinesAsync(cmsGitModulesPath, lines);
-            }
-
-            // Optionally, remove the nested submodule's directory if it exists
-            string nestedSubmodulePath = Path.Combine(_tempDir, modulePath, "core");
-            if (Directory.Exists(nestedSubmodulePath))
-            {
-                Directory.Delete(nestedSubmodulePath, true);
             }
         }
 
@@ -123,17 +76,16 @@ namespace Myrtus.Clarity.Generator.Common
             _status.Status = "[bold yellow]Renaming project files and contents...[/]";
 
             var oldName = _config.Template.TemplateName;
-            var oldCoreName = oldName + ".Core";
 
             var allDirectories = Directory.GetDirectories(_tempDir, "*", SearchOption.AllDirectories)
-                                        .OrderBy(d => d.Length)
-                                        .ToList();
+                                          .OrderBy(d => d.Length)
+                                          .ToList();
 
             foreach (var dir in allDirectories)
             {
                 if (ShouldSkipPath(dir)) continue;
 
-                string newDir = dir.Replace(oldName, newName);
+                string newDir = dir.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
                 if (dir != newDir && !Directory.Exists(newDir))
                 {
                     Directory.Move(dir, newDir);
@@ -147,7 +99,8 @@ namespace Myrtus.Clarity.Generator.Common
 
                 await RenameFileContentsAsync(file, oldName, newName);
 
-                if (file.EndsWith(".sln.DotSettings"))
+                // Remove leftover ReSharper / Rider settings
+                if (file.EndsWith(".sln.DotSettings", StringComparison.OrdinalIgnoreCase))
                 {
                     File.Delete(file);
                 }
@@ -165,36 +118,125 @@ namespace Myrtus.Clarity.Generator.Common
             }
         }
 
+        private async Task AddModuleAsync(string moduleName, string repoUrl)
+        {
+            _status.Status = $"[bold yellow]Adding module '{moduleName}' as a submodule...[/]";
+
+            // Define the relative path where the module will be added
+            string modulePath = Path.Combine("modules", moduleName);
+
+            // Ensure the 'modules' directory exists
+            string modulesDirectory = Path.Combine(_tempDir, "modules");
+            if (!Directory.Exists(modulesDirectory))
+            {
+                Directory.CreateDirectory(modulesDirectory);
+            }
+
+            var gitCommand = $"submodule add {repoUrl} \"{modulePath}\"";
+            var result = await RunProcessAsync("git", gitCommand, _tempDir);
+
+            if (!result.Success)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] Failed to add module '{moduleName}': {result.Error}");
+                return;
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"[green]Success:[/] Module '{moduleName}' added successfully.");
+            }
+
+            // Prevent initialization of nested submodules (like 'core/') within the CMS module
+            string cmsGitModulesPath = Path.Combine(_tempDir, ".gitmodules");
+            if (File.Exists(cmsGitModulesPath))
+            {
+                var lines = File.ReadAllLines(cmsGitModulesPath).ToList();
+                lines.RemoveAll(line => line.Contains($"path = {modulePath}/core", StringComparison.OrdinalIgnoreCase));
+                await File.WriteAllLinesAsync(cmsGitModulesPath, lines);
+            }
+
+            // Optionally, remove the nested submodule's directory if it exists
+            string nestedSubmodulePath = Path.Combine(_tempDir, modulePath, "core");
+            if (Directory.Exists(nestedSubmodulePath))
+            {
+                Directory.Delete(nestedSubmodulePath, true);
+            }
+        }
+
         private bool ShouldSkipPath(string path)
         {
-            return path.Contains(".git") ||
-                   path.Contains("Migrations") ||
-                   path.Contains("tests") ||
-                   path.Contains("bin") ||
-                   path.Contains("obj") ||
-                   path.EndsWith(".Core") ||
-                   path.Contains($"{Path.DirectorySeparatorChar}.Core{Path.DirectorySeparatorChar}");
+            if (_config.SkipPaths == null || !_config.SkipPaths.Any())
+                return false; // If no skip list is defined, skip nothing.
+
+            string normalizedPath = path.Replace('\\', '/').ToLowerInvariant();
+
+            foreach (string skipPattern in _config.SkipPaths)
+            {
+                string normalizedSkip = skipPattern.Replace('\\', '/').ToLowerInvariant();
+                if (normalizedPath.Contains(normalizedSkip))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private async Task RenameFileContentsAsync(string file, string oldName, string newName)
         {
+            // 1) Read the file content
             var content = await File.ReadAllTextAsync(file);
-            content = ReplaceContentExcludingCore(content, oldName, newName);
 
-            if (file.EndsWith(".cs") || file.EndsWith(".cshtml"))
+            // 2) Replace all occurrences of oldName (case-insensitive),
+            //    but do NOT replace if it's followed by ".Core"
+            //    (we do a negative lookahead to exclude .Core)
+            //    We also specify RegexOptions.IgnoreCase
+            content = Regex.Replace(
+                content,
+                $@"{Regex.Escape(oldName)}(?!\.Core)",
+                newName,
+                RegexOptions.IgnoreCase
+            );
+
+            // 3) For .cs or .cshtml, also fix explicit "using" lines:
+            //    e.g. `using Myrtus.Clarity.*` => `using DenemeApp3.*`
+            if (file.EndsWith(".cs", StringComparison.OrdinalIgnoreCase)
+                || file.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase))
             {
-                content = UpdateUsingStatements(content, oldName, newName);
+                content = Regex.Replace(
+                    content,
+                    $@"using\s+{Regex.Escape(oldName)}\.(?!Core)",
+                    $"using {newName}.",
+                    RegexOptions.IgnoreCase
+                );
+
+                // 4) Also handle explicit "namespace Myrtus.Clarity.*" lines
+                //    so that `namespace Myrtus.Clarity.Domain.Users` => `namespace DenemeApp3.Domain.Users`
+                content = Regex.Replace(
+                    content,
+                    $@"namespace\s+{Regex.Escape(oldName)}\.(?!Core)",
+                    $"namespace {newName}.",
+                    RegexOptions.IgnoreCase
+                );
             }
 
-            if (file.EndsWith(".csproj"))
+            // 5) For .csproj, update <ProjectReference Include="...">
+            if (file.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
             {
-                content = UpdateProjectReferences(content, oldName, newName);
+                content = Regex.Replace(
+                    content,
+                    $@"<ProjectReference\s+Include=""(.*?){Regex.Escape(oldName)}(?!\.Core)(.*?)""",
+                    m => $"<ProjectReference Include=\"{m.Groups[1].Value}{newName}{m.Groups[2].Value}\"",
+                    RegexOptions.IgnoreCase
+                );
             }
 
+            // 6) Write updated content back out
             await File.WriteAllTextAsync(file, content);
 
-            string newFilePath = file.Replace(oldName, newName);
-            if (file != newFilePath)
+            // 7) Finally, rename the file itself if it contains oldName
+            //    (e.g. a .sln file or any file that had the oldName in the path)
+            string newFilePath = file.Replace(oldName, newName, StringComparison.OrdinalIgnoreCase);
+            if (!string.Equals(file, newFilePath, StringComparison.OrdinalIgnoreCase))
             {
                 string newFileDirectory = Path.GetDirectoryName(newFilePath)!;
                 Directory.CreateDirectory(newFileDirectory);
@@ -204,23 +246,6 @@ namespace Myrtus.Clarity.Generator.Common
                     File.Move(file, newFilePath);
                 }
             }
-        }
-
-        private string ReplaceContentExcludingCore(string content, string oldName, string newName)
-        {
-            return Regex.Replace(content, $@"\b{Regex.Escape(oldName)}\b(?!\.Core)", newName);
-        }
-
-        private string UpdateUsingStatements(string content, string oldName, string newName)
-        {
-            return Regex.Replace(content, $@"using\s+{Regex.Escape(oldName)}\.(?!Core)", $"using {newName}.");
-        }
-
-        private string UpdateProjectReferences(string content, string oldName, string newName)
-        {
-            return Regex.Replace(content,
-                $@"<ProjectReference\s+Include=""(.*?){Regex.Escape(oldName)}(?!\.Core)(.*?)""",
-                m => $"<ProjectReference Include=\"{m.Groups[1].Value}{newName}{m.Groups[2].Value}\"");
         }
 
         private void FinalizeProjectAsync(string projectName, string outputDir)
@@ -241,11 +266,30 @@ namespace Myrtus.Clarity.Generator.Common
             tree.AddNode($"[blue]Location:[/] [link={finalPath}]{finalPath}[/]");
             tree.AddNode($"[blue]Template:[/] {_config.Template.TemplateName}");
 
-            AnsiConsole.Write(new Panel(tree)
-                .Header("Success!")
-                .BorderColor(Color.Green));
+            AnsiConsole.Write(
+                new Panel(tree)
+                    .Header("Success!")
+                    .BorderColor(Color.Green)
+            );
 
             AnsiConsole.MarkupLine("\n[grey]Click the path above to open the project location[/]");
+        }
+
+        private void ForceDeleteDirectory(string directoryPath)
+        {
+            var directoryInfo = new DirectoryInfo(directoryPath);
+
+            foreach (var fileInfo in directoryInfo.GetFiles("*", SearchOption.AllDirectories))
+            {
+                fileInfo.Attributes = FileAttributes.Normal;
+            }
+
+            foreach (var subDirInfo in directoryInfo.GetDirectories("*", SearchOption.AllDirectories))
+            {
+                subDirInfo.Attributes = FileAttributes.Normal;
+            }
+
+            Directory.Delete(directoryPath, true);
         }
 
         private record ProcessResult(bool Success, string Output, string Error);
@@ -273,8 +317,14 @@ namespace Myrtus.Clarity.Generator.Common
             var output = new List<string>();
             var error = new List<string>();
 
-            process.OutputDataReceived += (s, e) => { if (e.Data != null) output.Add(e.Data); };
-            process.ErrorDataReceived += (s, e) => { if (e.Data != null) error.Add(e.Data); };
+            process.OutputDataReceived += (s, e) =>
+            {
+                if (e.Data != null) output.Add(e.Data);
+            };
+            process.ErrorDataReceived += (s, e) =>
+            {
+                if (e.Data != null) error.Add(e.Data);
+            };
 
             process.Start();
             process.BeginOutputReadLine();
@@ -284,7 +334,8 @@ namespace Myrtus.Clarity.Generator.Common
             return new ProcessResult(
                 process.ExitCode == 0,
                 string.Join(Environment.NewLine, output),
-                string.Join(Environment.NewLine, error));
+                string.Join(Environment.NewLine, error)
+            );
         }
     }
 }

--- a/src/Myrtus.Clarity.Generator.DataAccess/appsettings.json
+++ b/src/Myrtus.Clarity.Generator.DataAccess/appsettings.json
@@ -18,5 +18,10 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
-  }
+  },
+  "SkipPaths": [
+    ".git",
+    ".Core",
+    "core"
+  ]
 }


### PR DESCRIPTION
Added SkipPaths property to AppSettings for path exclusion. Simplified _availableModules initialization with target-typed new. Reordered method calls in RenameProjectAsync.
Used pattern matching for modulesToAdd null and count check. Introduced ForceDeleteDirectory for safe directory deletion. Refactored AddModuleAsync for readability and maintainability. Updated ShouldSkipPath to use SkipPaths and improved readability. Enhanced RenameFileContentsAsync for case-insensitive replacements. Removed redundant methods integrated into RenameFileContentsAsync. Improved formatting and readability of FinalizeProjectAsync and RunProcessAsync. Updated appsettings.json with default SkipPaths configuration.