### PR TITLE
feat: enhance file renaming and update template name

### DIFF
--- a/src/Myrtus.Clarity.Generator.DataAccess/appsettings.json
+++ b/src/Myrtus.Clarity.Generator.DataAccess/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Template": {
     "GitRepoUrl": "https://github.com/sercanio/AppTemplate.git",
-    "TemplateName": "EcoFind"
+    "TemplateName": "AppTemplate"
   },
   "Modules": [
     {


### PR DESCRIPTION
Updated `RenameFileContentsAsync` to replace occurrences of `oldName` with `newName` in `.cs`, `.cshtml`, and `.cshtml.cs` files, with case-insensitive checks for `.csproj` files. Enhanced `UpdateUsingStatements` to support both `using` and `@using` directives. Removed `FinalizeProjectAsync` method. Changed `TemplateName` in `appsettings.json` from "EcoFind" to "AppTemplate".