### PR TITLE
chore: add package license file reference in project file

### DIFF
--- a/src/Myrtus.Clarity.Generator.Presentation/Myrtus.Clarity.Generator.Presentation.csproj
+++ b/src/Myrtus.Clarity.Generator.Presentation/Myrtus.Clarity.Generator.Presentation.csproj
@@ -15,6 +15,7 @@
 		<PackageTags>project-generator;code-generation;cli</PackageTags>
 		<RepositoryUrl>https://github.com/sercanio/Myrtus.Clarity.Generator</RepositoryUrl>
 		<LicenseUrl>https://opensource.org/licenses/MIT</LicenseUrl>
+		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 	</PropertyGroup>
 
 	<!-- Debug Configuration -->


### PR DESCRIPTION
Included `<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>` to specify the location of the package license file.