### PR TITLE
fix: update license file path and include in package

### DIFF
--- a/src/Myrtus.Clarity.Generator.Presentation/Myrtus.Clarity.Generator.Presentation.csproj
+++ b/src/Myrtus.Clarity.Generator.Presentation/Myrtus.Clarity.Generator.Presentation.csproj
@@ -15,8 +15,12 @@
 		<PackageTags>project-generator;code-generation;cli</PackageTags>
 		<RepositoryUrl>https://github.com/sercanio/Myrtus.Clarity.Generator</RepositoryUrl>
 		<LicenseUrl>https://opensource.org/licenses/MIT</LicenseUrl>
-		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+		<PackageLicenseFile>../../LICENSE.txt</PackageLicenseFile>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="../../LICENSE.txt" Pack="true" PackagePath="" />
+	</ItemGroup>
 
 	<!-- Debug Configuration -->
 	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
Changed the `PackageLicenseFile` path to `../../LICENSE.txt` to reflect its new location. Added an `ItemGroup` to ensure the license file is included in the package with `Pack="true"`.